### PR TITLE
Allow PlayerMobs to have a different display name than their skin name

### DIFF
--- a/src/main/java/se/gory_moon/player_mobs/utils/DeathHandler.java
+++ b/src/main/java/se/gory_moon/player_mobs/utils/DeathHandler.java
@@ -14,6 +14,7 @@ import net.minecraft.nbt.CompoundNBT;
 import net.minecraft.nbt.NBTUtil;
 import net.minecraft.util.DamageSource;
 import net.minecraft.util.EntityDamageSource;
+import net.minecraft.util.text.StringTextComponent;
 import net.minecraft.world.GameRules;
 import net.minecraftforge.event.entity.living.LivingDeathEvent;
 import net.minecraftforge.event.entity.living.LivingDropsEvent;
@@ -69,6 +70,14 @@ public class DeathHandler {
             GameProfile gameprofile = entity instanceof PlayerMobEntity ?
                     ((PlayerMobEntity) entity).getProfile():
                     ((PlayerEntity) entity).getGameProfile();
+            if (entity instanceof PlayerMobEntity) {
+                PlayerMobEntity pmentity = (PlayerMobEntity) entity;
+                String skinName = pmentity.getUsername().getSkinName();
+                String displayName = pmentity.getUsername().getDisplayName();
+                if (!skinName.equals(displayName)) {
+                    stack.setDisplayName(new StringTextComponent(displayName + "'s Head"));
+                }
+            }
             stack.getOrCreateTag().put("SkullOwner", NBTUtil.writeGameProfile(new CompoundNBT(), gameprofile));
             return stack;
         }

--- a/src/main/java/se/gory_moon/player_mobs/utils/PlayerName.java
+++ b/src/main/java/se/gory_moon/player_mobs/utils/PlayerName.java
@@ -1,0 +1,62 @@
+package se.gory_moon.player_mobs.utils;
+
+import net.minecraft.util.StringUtils;
+
+public class PlayerName {
+	private String skinName;
+	private String displayName;
+
+	public PlayerName(String combined) {
+		String[] parts = combined.split(":", 2);
+		skinName = parts[0];
+		if (parts.length > 1) {
+			displayName = parts[1];
+		}
+	}
+
+	public PlayerName(String skin, String display) {
+		skinName = skin;
+		if (!StringUtils.isNullOrEmpty(display)) {
+			displayName = display;
+		}
+	}
+	public String getCombinedNames() {
+		if (StringUtils.isNullOrEmpty(displayName) || skinName.equals(displayName)) {
+			return skinName;
+		} else {
+			return skinName + ":" + displayName;
+		}
+	}
+	public void setNames(String name) {
+		skinName = displayName = name;
+	}
+	public void setSkinName(String name) {
+		skinName = name;
+	}
+	public String getSkinName() {
+		return skinName;
+	}
+	public void setDisplayName(String display) {
+		displayName = display;
+	}
+	public String getDisplayName() {
+		if (!StringUtils.isNullOrEmpty(displayName)) {
+			return displayName;
+		} else {
+			return skinName;
+		}
+	}
+
+	@Override
+	public boolean equals(Object o) {
+		if (o instanceof PlayerName) {
+			PlayerName other = (PlayerName) o;
+			return this.getCombinedNames().equals(other.getCombinedNames());
+		}
+		return false;
+	}
+	@Override
+	public String toString() {
+		return getCombinedNames();
+	}
+}


### PR DESCRIPTION
This is useful for cases where, for example, someone has different
Minecraft and Twitch usernames, and wants their PlayerMob to be known by
their Twitch username so they will be recognized.

Change input name list format from `<name>` to `<name>[:<display name>]`.

This is backwards compatible with the previous name list format.

All PlayerMobs in existing worlds retain their name.