### PR TITLE
Remote fetch timer never reset

### DIFF
--- a/src/main/java/se/gory_moon/player_mobs/utils/NameManager.java
+++ b/src/main/java/se/gory_moon/player_mobs/utils/NameManager.java
@@ -108,6 +108,7 @@ public class NameManager {
             syncTime++;
 
             if (tickTime > 0 && syncTime >= tickTime || firstSync) {
+                syncTime = 0;
                 firstSync = false;
                 reloadRemoteLinks();
             }


### PR DESCRIPTION
The remote fetch timer was never reset causing it to spam the endpoints when it passed.