### PR TITLE
Added call to load configs at Load event

### DIFF
--- a/src/main/java/se/gory_moon/player_mobs/Configs.java
+++ b/src/main/java/se/gory_moon/player_mobs/Configs.java
@@ -177,6 +177,11 @@ public class Configs {
         }
 
         @SubscribeEvent
+        void onLoad(ModConfigEvent.Loading event) {
+            configReload();
+        }
+
+        @SubscribeEvent
         void onReload(ModConfigEvent.Reloading event) {
             configReload();
         }


### PR DESCRIPTION
The `dimensionBlockList` is always empty when it's checking `isDimensionBlocked` because the configReload is never called to populate it.  This wires up call in the `onLoad` event.