### PR TITLE
Fixed crash issue with long player names

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -3,7 +3,7 @@ plugins {
     id 'eclipse'
     id 'idea'
     id 'maven-publish'
-    id 'net.neoforged.gradle.userdev' version '7.0.158'
+    id 'net.neoforged.gradle.userdev' version '7.0.176'
 }
 
 tasks.named('wrapper', Wrapper).configure {
@@ -42,7 +42,6 @@ minecraft.accessTransformers.file rootProject.file('src/main/resources/META-INF/
 runs {
     configureEach {
         systemProperty 'forge.logging.markers', 'REGISTRIES'
-        //property 'forge.logging.markers', 'CORE,LOADING,REGISTRIES'
 
         // Recommended logging level for the console
         systemProperty 'forge.logging.console.level', 'debug'
@@ -62,7 +61,7 @@ runs {
     server {
         // Comma-separated list of namespaces to load gametests from. Empty = all namespaces.
         systemProperty 'forge.enabledGameTestNamespaces', project.mod_id
-        arguments '--nogui'
+        arguments.add '--nogui'
     }
 
     // This run config launches GameTestServer and runs all registered gametests, then exits.

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,14 +4,14 @@ org.gradle.daemon=false
 org.gradle.debug=false
 
 # you can also find the latest versions at: https://parchmentmc.org/docs/getting-started
-neogradle.subsystems.parchment.minecraftVersion=1.21
-neogradle.subsystems.parchment.mappingsVersion=2024.07.28
+neogradle.subsystems.parchment.minecraftVersion=1.21.1
+neogradle.subsystems.parchment.mappingsVersion=2024.11.17
 neogradle.subsystems.devLogin.enabled=true
 
 # Environment Properties
 minecraft_version=1.21.1
 minecraft_version_range=[1.21,1.21.1)
-neo_version=21.1.18
+neo_version=21.1.92
 neo_version_range=[21.1,)
 loader_version_range=[4,)
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.9-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.12-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/src/main/java/se/gory_moon/player_mobs/entity/PlayerMobEntity.java
+++ b/src/main/java/se/gory_moon/player_mobs/entity/PlayerMobEntity.java
@@ -549,7 +549,7 @@ public class PlayerMobEntity extends Monster implements RangedAttackMob, Crossbo
         }
 
         if (!Objects.equals(oldName, name)) {
-            setProfile(new ResolvableProfile(Optional.of(name.skinName()), Optional.empty(), new PropertyMap()));
+            setProfile(new ResolvableProfile(Optional.of(StringUtil.truncateStringIfNecessary(name.skinName(),16, false)), Optional.empty(), new PropertyMap()));
         }
     }
 }


### PR DESCRIPTION
The crash was caused by the profile lookup system to get the UUID and textures.
Just added a limit on the profile lookup, the in-game name shown is still using the full length.

Fixes #68 